### PR TITLE
Add map not territory

### DIFF
--- a/Map-Not-Territory.md
+++ b/Map-Not-Territory.md
@@ -34,3 +34,35 @@ To avoid the error, use these mental structural devices:
     * **Goal:** Undermines the trap of static assumptions.
     * *Example:* `MarketData_2025` is not `MarketData_2026`.
 * **The Chain of Abstraction:** Mentally track how far your model is from the raw, sensory event. The further you are from the territory, the more caution is required.
+
+---
+
+# Non-Aristotelian Orientation: Debugging Your Logic Gates
+
+**Core Principle:** Reject the structural limitations of binary, static, Aristotelian logic in favor of a dynamic, multi-valued, scientific orientation that aligns with reality.
+
+The traditional (Aristotelian) framework, based on the three laws of thought (Identity, Non-Contradiction, Excluded Middle), is useful for basic categorization but fails spectacularly when dealing with continuous, changing, unique systems (i.e., the Territory). The Non-A mindset is the system upgrade.
+
+## 🎛️ Logic Comparison: Static vs. Dynamic
+
+| Standard Logic | Aristotelian (A-Logic) | Non-Aristotelian (Non-A Logic) | Implication for Systems |
+| :--- | :--- | :--- | :--- |
+| **Identity** | A is A (Fixed, absolute equivalence) | A is **NOT** A (Non-Identity, things are always changing) | Forces continuous **indexing** and **dating** of all concepts. |
+| **Excluded Middle** | Binary: Either A or not-A (Good or Bad) | Multi-Valued: Infinite shades of grey (Degrees of A) | Allows for systems that are "mostly functional" or "good in context X." Avoids rigidity. |
+| **Focus** | Intensional (Focus on the **definition/label**) | Extensional (Focus on the **observable event**) | Prioritizes physical data and direct experience over labels (Map vs. Territory check). |
+
+## 🛠️ The Non-A Directives
+
+To operate on a Non-Aristotelian basis, your approach must include:
+
+1.  **Dating and Indexing:**
+    * **Goal:** Demolish the Law of Identity.
+    * Every concept, person, or plan must be treated as unique and time-bound. (e.g., `Plan_2025-12` $\neq$ `Plan_2026-01`, `Kvinoja_am` $\neq$ `Kvinoja_pm`).
+2.  **Using 'ETC.':**
+    * **Goal:** Acknowledge the Incompleteness of the Map.
+    * Mentally or physically add "etc." to the end of all descriptions and lists to remind yourself that details have been omitted and the description is partial. You can never say everything about a thing.
+3.  **Using Hyphens (Non-Elementality):**
+    * **Goal:** Demolish the Excluded Middle in certain contexts.
+    * Recognize that certain concepts cannot be separated in reality, even if language tries to split them (e.g., **time-space**, **mind-body**). Your code isn't just "logic" or "data"; it's a **structure-process**.
+
+By adopting this logic, you build systems that are inherently more flexible and capable of adjusting to the chaotic reality of the Territory. It's the logic of a constantly self-debugging system.

--- a/Map-Not-Territory.md
+++ b/Map-Not-Territory.md
@@ -1,0 +1,36 @@
+# The Map Is Not the Territory: Model vs. Reality
+
+**Source:** Alfred Korzybski (General Semantics)
+**Core Principle:** Do not confuse your conceptual models (Maps) with the actual, non-verbal, complex world (Territory).
+
+This principle is critical for avoiding cognitive rigidity and ensuring that your systems (code, PM, music, life) are based on *reality* rather than *assumptions*.
+
+## :world_map: The Map vs. Territory Triad
+
+| Component | The **Map** (The Model/Abstraction) | The **Territory** (The Reality/Event) | The **Confusion** (The Error) |
+| :--- | :--- | :--- | :--- |
+| **What it Is** | Any representation: language, theories, labels, beliefs, plans, résumés, mental models. | The actual, unique, physical, complex, and neutral world itself. | Equating the Map with the Territory (i.e., "The label *is* the thing"). |
+| **Key Attributes** | Static, structured, simplified, *necessarily* incomplete. Can be wrong or outdated. | Dynamic, un-labelable, total complexity. The only source of truth. | Leads to rigidity, maladjustment, and clinging to plans that no longer work. |
+| **The Rule** | The map is **NOT** the territory. It is a useful, disposable tool for navigating. | The territory is the **final arbiter**. If the map fails, the territory wins. | **Extensionalize** (touch the reality) and **update** the map immediately. |
+
+***
+
+## :octagonal_sign: Why the Map is Always Wrong (But Useful)
+
+The Map must always deviate from the Territory in three essential ways:
+
+1.  **The Map is Incomplete (Omission):** A 1:1 map would be useless. The map must leave out details to be practical. *Trap: Thinking what isn't in your plan doesn't matter in reality.*
+2.  **The Map is Abstract (Reduction):** Words and labels exist at a higher level than the physical event. The word "Docker" is not the running container; the plan is not the project's actual state. *Trap: Treating a category or label (e.g., "lazy," "perfect system") as the full, complex reality.*
+3.  **The Map is Reflexive (Influence):** Our maps (beliefs, attitudes) change our actions, which then shape the future territory. *Trap: Letting an outdated self-concept ("I'm bad at X") prevent you from taking action in the territory, thus solidifying the flawed map.*
+
+## :hammer_and_wrench: Tools for Self-Correction
+
+To avoid the error, use these mental structural devices:
+
+* **Indexing:** Use subscripts to remind yourself of uniqueness.
+    * **Goal:** Undermines the trap of fixed labels.
+    * *Example:* `Theory_A` is not `Theory_B`; `k.greyZ_yesterday` is not `k.greyZ_today`.
+* **Dating:** Add time stamps to concepts and observations.
+    * **Goal:** Undermines the trap of static assumptions.
+    * *Example:* `MarketData_2025` is not `MarketData_2026`.
+* **The Chain of Abstraction:** Mentally track how far your model is from the raw, sensory event. The further you are from the territory, the more caution is required.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ I figure it would be a waste not to at least attempt documenting the lessons tha
 - [Regulation Scripts](./Regulation-Scripts.md)
 - [Thermal Regulation](./Thermal-Regulation.md)
 - [Sleep Protocols](./Sleep-Protocols.md)
+- [Map Not Territory](./Map-Not-Territory.md)
 
 ---
 

--- a/The-Core-Guide.md
+++ b/The-Core-Guide.md
@@ -15,6 +15,7 @@
 - [Regulation Scripts](#regulation-scripts)
 - [Thermal Regulation](#thermal-regulation)
 - [Sleep Protocols](#sleep-protocols)
+- [Map Not Territory](#map-not-territory)
 
 ## **The Manifesto**
 
@@ -113,3 +114,6 @@ See: [Thermal-Regulation.md](Thermal-Regulation.md)
 
 ## **Sleep Protocols**
 See: [Sleep-Protocols.md](Sleep-Protocols.md)
+
+## **Map Not Territory**
+See: [Map-Not-Territory.md](Map-Not-Territory.md)

--- a/main().md
+++ b/main().md
@@ -80,3 +80,6 @@ Scripts for managing social network identity and authentication.
 1. Passive IFF System (Hardware Skins & Tattoos)
 Purpose: To function as a passive Identify Friend or Foe (IFF) transponder, acting as a social firewall to filter unauthenticated or incompatible network traffic ("normies"). It broadcasts a clear, non-verbal signal about your system's custom firmware, allowing other custom builds to recognize you and default configurations to self-select out.
 Mechanism: By permanently altering the chassis's visual checksum, you create a non-verbal authentication layer. It saves significant processing power that would otherwise be spent on actively negotiating basic compatibility with every node on the network. It's a one-time hardware investment for a lifetime of passive social filtering.
+
+/mind/map_not_territory.md
+The Map Is Not the Territory: Model vs. Reality. A core principle for distinguishing conceptual models from the actual complex world. To avoid confusing your internal maps with the external territory.


### PR DESCRIPTION
re-open how to human addition to dex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new conceptual module emphasizing model-vs-reality and non-Aristotelian thinking.
> 
> - New `Map-Not-Territory.md` with principles, self-correction tools (indexing, dating), and Non-A directives
> - README and `The-Core-Guide.md` updated to include and link the new module in TOCs and reference sections
> - `main().md` library index extended with `/mind/map_not_territory.md` entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14abdddaadf005a9339170521aeab4f0603fbaf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation introducing "Map Not Territory" concepts, including frameworks, rules for updating maps, practical tools, and debugging perspectives.
  * Updated table of contents and core guide references to include the new "Map Not Territory" section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->